### PR TITLE
Allow moveNode to be canceled through ev.preventDefault()

### DIFF
--- a/tree.jquery.coffee
+++ b/tree.jquery.coffee
@@ -1047,21 +1047,24 @@ class JqTreeWidget extends MouseWidget
             position = @hovered_area.position
             previous_parent = moved_node.parent
 
-            @tree.moveNode(moved_node, target_node, position)
-
             if position == Position.INSIDE
                 @hovered_area.node.is_open = true
 
+            doMove = =>
+              @tree.moveNode(moved_node, target_node, position)
+              @element.empty()
+              @_createDomElements(@tree)
+
             event = $.Event('tree.move')
-            event.move_info = 
+            event.move_info =
                 moved_node: moved_node
                 target_node: target_node
                 position: Position.getName(position)
                 previous_parent: previous_parent
-            @element.trigger(event)
+                do_move: doMove
 
-            @element.empty()
-            @_createDomElements(@tree)
+            @element.trigger(event)
+            doMove() unless event.isDefaultPrevented()
 
     _clear: ->
         @drag_element.remove()

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -1325,26 +1325,33 @@ limitations under the License.
     };
 
     JqTreeWidget.prototype._moveItem = function() {
-      var event, moved_node, position, previous_parent, target_node;
+      var doMove, event, moved_node, position, previous_parent, target_node,
+        _this = this;
       if (this.hovered_area && this.hovered_area.position !== Position.NONE) {
         moved_node = this.current_item.node;
         target_node = this.hovered_area.node;
         position = this.hovered_area.position;
         previous_parent = moved_node.parent;
-        this.tree.moveNode(moved_node, target_node, position);
         if (position === Position.INSIDE) {
           this.hovered_area.node.is_open = true;
         }
+        doMove = function() {
+          _this.tree.moveNode(moved_node, target_node, position);
+          _this.element.empty();
+          return _this._createDomElements(_this.tree);
+        };
         event = $.Event('tree.move');
         event.move_info = {
           moved_node: moved_node,
           target_node: target_node,
           position: Position.getName(position),
-          previous_parent: previous_parent
+          previous_parent: previous_parent,
+          do_move: doMove
         };
         this.element.trigger(event);
-        this.element.empty();
-        return this._createDomElements(this.tree);
+        if (!event.isDefaultPrevented()) {
+          return doMove();
+        }
       }
     };
 


### PR DESCRIPTION
Here is a suggestion for allowing the move action to be cancelable or confirmable.

Here is a possible usage:

``` javascript
$('#tree').bind('tree.move', function(ev) {
  ev.preventDefault()
  jConfirm('Are you sure?', 'Please confirm', function(confirmed) {
    if (confirmed) ev.move_info.do_move()
  })
})
```

In my particular case, I'm not using do_move as I need to reload the parent of the target node (or the target node itself if the position is 'inside').
