### PR TITLE
Ensuring on refresh of the Tree that previously hidden/closed subtrees remain hidden/closed.

### DIFF
--- a/tree.jquery.coffee
+++ b/tree.jquery.coffee
@@ -622,7 +622,12 @@ class JqTreeWidget extends MouseWidget
             else
                 class_string = ' class="tree"'
 
-            return $("<ul#{ class_string }></ul>")
+            ul = $("<ul#{ class_string }></ul>")
+
+            if !is_open
+                ul.hide()
+
+            return ul
 
         createLi = (node) =>
             if node.hasChildren()


### PR DESCRIPTION
The Javascript I write is not Coffeescript, and I don't know QUnit, but thought it wouldn't hurt to submit this fix anyway; I think it is a simple enough fix that I didn't mess up the Coffeescript syntax.

I start with a tree 1 level deep with multiple folder nodes. Clicking a node triggers `loadData` for that node via Ajax. When the refresh of the parent _(the Tree in this case)_ occurs, if other branches at the same level had previously been marked as closed, their subtree `<ul>` is not re-hidden. This causes all of the previously expanded and closed subtrees to pop open when the refresh is performed.
