### PR TITLE
Unset internal pointer to previously selected node on DOM deselect

### DIFF
--- a/tree.jquery.coffee
+++ b/tree.jquery.coffee
@@ -439,6 +439,7 @@ class JqTreeWidget extends MouseWidget
         if @options.selectable
             if @selected_node
                 @_getNodeElementForNode(@selected_node).deselect()
+                @selected_node = null
 
             if node
                 @_getNodeElementForNode(node).select()


### PR DESCRIPTION
``` javascript
$tree.tree('selectNode');
```

When calling the above without passing a `node` parameter, the majority
of jqTree's `selectNode` method is skipped _(since no `node` has bene
provided, there is nothing to select)_.

Regardless of `node` being passed, the currently selected node is first
deselected. The deselect happens in the DOM, but the internal pointer to
the selected node is not cleared. Calling

``` javascript
$tree.tree('getSelectedNode');
```

will still _(incorrectly)_ return the _(now *_deselected*_)_ node.

The small change here fixes that, causing `getSelectedNode` to properly
return `false`.
