### PR TITLE
Added handlers onTreeReady and onLiAppended

### DIFF
--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -972,6 +972,16 @@ limitations under the License.
         escaped_name = escapeIfNecessary(node.name);
         return $("<li><div><span class=\"title\">" + escaped_name + "</span></div></li>");
       };
+      liAppended = function(node, $li) {
+        if (_this.options.onLiAppended) {
+          _this.options.onLiAppended(node, $li);
+        }
+      };
+      treeReady = function($ul) {
+        if (_this.options.onTreeReady) {
+          _this.options.onTreeReady($ul);
+        }
+      };
       createFolderLi = function(node) {
         var button_class, escaped_name, folder_class, getButtonClass, getFolderClass;
         getButtonClass = function() {
@@ -1003,12 +1013,18 @@ limitations under the License.
           child = children[_i];
           $li = createLi(child);
           $ul.append($li);
+          liAppended(child, $li);
           child.element = $li[0];
           $li.data('node', child);
           if (child.hasChildren()) {
             doCreateDomElements($li, child.children, false, child.is_open);
           }
         }
+        
+        if (is_root_node) {
+          treeReady($ul);
+        }
+        
         return null;
       };
       if (from_node && from_node.parent) {


### PR DESCRIPTION
It is quite useful to have handlers to manage the entire tree once it is
completed and appended to the DOM, as well a handler to manage the Li
once it is already appended to the DOM.
One useful example to these
handlers is when you want to add elements that are related to more than
one Li, for example, when creating a workflow chart.
I don't have the
knowledge (nor the time to learn) Coffee Script, so I just updated the
compiled JS file.
