### PR TITLE
allow dataUrl value to contain existing parameters.

### DIFF
--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -1027,7 +1027,11 @@ limitations under the License.
         return data_url(node);
       } else {
         if (node) {
-          data_url += "?node=" + node.id;
+            if(data_url.indexOf('?') >= 0) {
+                data_url += "&node=" + node.id;
+            } else {
+                data_url += "?node=" + node.id;
+            }
         }
         return data_url;
       }


### PR DESCRIPTION
The behaviour of dataUrl was naive, expecting a clean url without existing parameters. When creating a url for a node, now checks for existing "?" character, and uses "&" instead.
