### PR TITLE
Feat/selectable

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,8 +482,8 @@ $('#tree1').tree({
         Turn on selection of nodes.
     </p>
     <ul>
-        <li><strong>true</strong>: turn on selection of nodes</li>
-        <li><strong>false (default)</strong>: turn off selection of nodes</li>
+        <li><strong>true (default)</strong>: turn on selection of nodes</li>
+        <li><strong>false</strong>: turn off selection of nodes</li>
     </ul>
     <p>
         Example: turn on selection of nodes.

--- a/tree.jquery.coffee
+++ b/tree.jquery.coffee
@@ -472,7 +472,7 @@ class JqTreeWidget extends MouseWidget
         autoOpen: false  # true / false / int (open n levels starting at 0)
         saveState: false  # true / false / string (cookie name)
         dragAndDrop: false
-        selectable: false
+        selectable: true
         onCanSelectNode: null
         onSetStateFromStorage: null
         onGetStateFromStorage: null
@@ -1264,7 +1264,7 @@ class SelectNodeHandler
             if not @tree_widget.options.onCanSelectNode
                 return @tree_widget.options.selectable
 
-            return @tree_widget.options.onCanSelectNode(node)
+            return @tree_widget.options.selectable and @tree_widget.options.onCanSelectNode(node)
 
         mustToggle = (previous_node, node) ->
             if must_toggle and previous_node and node

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -821,7 +821,7 @@ limitations under the License.
       autoOpen: false,
       saveState: false,
       dragAndDrop: false,
-      selectable: false,
+      selectable: true,
       onCanSelectNode: null,
       onSetStateFromStorage: null,
       onGetStateFromStorage: null,
@@ -1807,7 +1807,7 @@ limitations under the License.
         if (!_this.tree_widget.options.onCanSelectNode) {
           return _this.tree_widget.options.selectable;
         }
-        return _this.tree_widget.options.onCanSelectNode(node);
+        return _this.tree_widget.options.selectable && _this.tree_widget.options.onCanSelectNode(node);
       };
       mustToggle = function(previous_node, node) {
         if (must_toggle && previous_node && node) {


### PR DESCRIPTION
`selectable` option now factors in to the result of CanSelect. If onCanSelectNode is used, `selectable and onCanSelectNode(node)` determines result, as was detailed in the doc.

Had to change default value of `selectable` from `false` to `true` so the default behavior in existing implementations would not be changed.

(Issue #130) 
