### PR TITLE
Adding "deselected_node" attribute to "event" object of "tree.select" event

### DIFF
--- a/src/tree.jquery.coffee
+++ b/src/tree.jquery.coffee
@@ -87,9 +87,10 @@ class JqTreeWidget extends MouseWidget
                     previous_node: node
                 )
         else
+            deselected_node = @getSelectedNode()
             @_deselectCurrentNode()
             @addToSelection(node)
-            @_triggerEvent('tree.select', node: node)
+            @_triggerEvent('tree.select', node: node, deselected_node: deselected_node)
             openParents()
 
         saveState()

--- a/test/test.js
+++ b/test/test.js
@@ -444,6 +444,37 @@ test('selectNode', function() {
     ok($tree.tree('isNodeSelected', node1));
 });
 
+test('selectNode when another node is selected', function() {
+    // setup
+    var $tree = $('#tree1');
+    $tree.tree({
+        data: example_data,
+        selectable: true
+    });
+
+    var node1 = $tree.tree('getTree').children[0];
+    var node2 = $tree.tree('getTree').children[1];
+    
+
+    // -- select node 'node2'
+    $tree.tree('selectNode', node2);
+    equal($tree.tree('getSelectedNode').name, 'node2');
+
+    // -- setting event
+    // -- is node 'node2' named 'deselected_node' in object's attributes?
+    stop();
+    $tree.bind('tree.select', function(e) {
+        start();
+        equal(e.deselected_node, node2);
+    });
+
+    // -- select node 'node1'; node 'node2' is selected before it
+    $tree.tree('selectNode', node1);
+    equal($tree.tree('getSelectedNode').name, 'node1');
+
+    ok($tree.tree('isNodeSelected', node1));
+});
+
 test('click toggler', function() {
     // setup
     stop();

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -821,7 +821,7 @@ limitations under the License.
     };
 
     JqTreeWidget.prototype._selectNode = function(node, must_toggle) {
-      var canSelect, openParents, saveState,
+      var canSelect, deselected_node, openParents, saveState,
         _this = this;
       if (must_toggle == null) {
         must_toggle = false;
@@ -865,10 +865,12 @@ limitations under the License.
           });
         }
       } else {
+        deselected_node = this.getSelectedNode();
         this._deselectCurrentNode();
         this.addToSelection(node);
         this._triggerEvent('tree.select', {
-          node: node
+          node: node,
+          deselected_node: deselected_node
         });
         openParents();
       }


### PR DESCRIPTION
Hi,

I found, that while of "tree.select" event's progress one can't to access to the node, that was selected before current node (that selecting catched by this event). But this object I need in commercial web-project very much (and I'm absolutely sure that this feature will help some peoples, which need to do something with deselected node).

I just added attribute, compiled all coffee-files into generally js-file (that on root) and wrote separate test for this behavior.

It's my first pull request, so sorry for possible errors or my not yes fluent english skills :)

P.S.: I use your plugin in RubyOnRails web-app.
