### PR TITLE
Fixes TypeError when removing nodes without ids that aren't selected

### DIFF
--- a/src/select_node_handler.coffee
+++ b/src/select_node_handler.coffee
@@ -38,7 +38,7 @@ class SelectNodeHandler
 
     removeFromSelection: (node, include_children=false) ->
         if not node.id
-            if node.element == @selected_single_node.element
+            if @selected_single_node && node.element == @selected_single_node.element
                 @selected_single_node = null
         else
             delete @selected_nodes[node.id]

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,7 @@ var example_data = [
             { label: 'child3', id: 127 }
         ]
     }
+    
 ];
 
 /*
@@ -777,6 +778,18 @@ test('removeNode', function() {
 
     // node is unselected
     equal($tree.tree('getSelectedNode'), false);
+
+    // 4. Remove unselected node without an id
+    $tree.tree('loadData', example_data2);
+
+    var c1 = $tree.tree('getNodeByName', 'c1');
+    
+    $tree.tree('removeNode', c1);
+
+    equal(
+        formatTitles($tree),
+        'main c2'
+    )
 });
 
 test('appendNode', function() {

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -1995,7 +1995,7 @@ limitations under the License.
         include_children = false;
       }
       if (!node.id) {
-        if (node.element === this.selected_single_node.element) {
+        if (this.selected_single_node && node.element === this.selected_single_node.element) {
           return this.selected_single_node = null;
         }
       } else {


### PR DESCRIPTION
I noticed that it was impossible to remove nodes that aren't selected and also do not have an id. Wrote a test case exposing the bug and fixed it.
