### PR TITLE
CSS3 Circle and style optimization

### DIFF
--- a/jqtree.css
+++ b/jqtree.css
@@ -93,7 +93,7 @@ ul.jqtree-tree li.jqtree-ghost span.jqtree-circle {
     width: 8px;
     position: absolute;
     top: -4px;
-    left: 2px;
+    left: -6px;
 }
 
 /* IE 6, 7, 8 */
@@ -110,7 +110,7 @@ ul.jqtree-tree li.jqtree-ghost span.jqtree-line {
     padding: 0;
     position: absolute;
     top: -1px;
-    left: 10px;
+    left: 2px;
     width: 100%;
 }
 


### PR DESCRIPTION
To simplify the change of the color scheme and provide high resolution display support I changed the grabbing line circle from image based to CSS3 based. IE6-8 still use the image as fallback.

To clarify the position of the grabbed node I also moved the line a bit to the left. This conforms to the viewing habits of users.
