### PR TITLE
Drag n drop box style dragging feature

### DIFF
--- a/build
+++ b/build
@@ -1,2 +1,2 @@
 # Build and watch coffeescript
-coffee -w -j tree.jquery.js -c src/simple.widget.coffee src/mouse.widget.coffee src/node.coffee src/elements_renderer.coffee src/tree.jquery.coffee src/save_state_handler.coffee src/select_node_handler.coffee src/drag_and_drop_handler.coffee src/scroll_handler.coffee src/key_handler.coffee
+coffee -w -j tree.jquery.js -c src/simple.widget.coffee src/mouse.widget.coffee src/node.coffee src/elements_renderer.coffee src/tree.jquery.coffee src/save_state_handler.coffee src/select_node_handler.coffee src/drag_and_drop_handler.coffee src/scroll_handler.coffee src/key_handler.coffee src/drag_and_drop_box_handler.coffee

--- a/docs_src/drag_and_drop_box.tmpl
+++ b/docs_src/drag_and_drop_box.tmpl
@@ -1,0 +1,50 @@
+{% extends "base" %}
+
+{% block title %}Javascript tree with box drag and drop{% endblock %}
+{% block h1 %}Example 11 - Drag and drop with box dragging {% endblock %}
+{% block previous_url %}icon_buttons.html{% endblock %}
+{% block previous_title %}Example 10{% endblock %}
+
+{% block next %}{% endblock %}
+
+{% block contents %}
+    <div id="tree1" data-url="/example_data/"></div>
+
+    <p>
+       Jqtree also supports a different "box" style method of drag and drop.
+	   Let's add this type of drag-and-drop support by setting the option
+	   <strong>dragAndDrop</strong> to 'box'. Additionally you will need styling
+	   that works with 'boxed' items. You can find an example in
+	   <strong>example.css</strong>. You can now drag tree nodes to another position with this box style.
+
+    </p>
+
+    <h3>html</h3>
+<pre><code class="language-markup">&lt;div id="tree1" data-url="/example_data/"&gt;&lt;/div&gt;</code></pre>
+
+    <h3>javascript</h3>
+<pre><code class="language-javascript">var $tree = $('#tree1');
+$tree.tree({
+  dragAndDrop: 'box',
+});
+</code></pre>
+{% endblock %}
+
+{% block script %}
+    <script>
+        $.mockjax({
+            url: '*',
+            response: function(options) {
+                this.responseText = ExampleData.example_data;
+            },
+            responseTime: 0
+        });
+
+        $(function() {
+            var $tree = $('#tree1');
+            $tree.tree({
+                dragAndDrop: 'box',
+            });
+        });
+    </script>
+{% endblock %}

--- a/docs_src/icon_buttons.tmpl
+++ b/docs_src/icon_buttons.tmpl
@@ -5,7 +5,8 @@
 
 {% block previous_url %}custom_html.html{% endblock %}
 {% block previous_title %}Example 9{% endblock %}
-{% block next %}{% endblock %}
+{% block next_url %}drag_and_drop_box.html{% endblock %}
+{% block next_title %}Example 11{% endblock %}
 
 {% block css %}
     <link rel="stylesheet" href="../extra/bower_components/fontawesome/css/font-awesome.min.css">

--- a/examples/drag_and_drop_box.html
+++ b/examples/drag_and_drop_box.html
@@ -9,41 +9,35 @@
     <link rel="stylesheet" href="../extra/bower_components/prism/themes/prism-okaidia.css">
     <link rel="stylesheet" href="example.css">
     <link rel="stylesheet" href="../jqtree.css">
-    
+
 </head>
 <body>
     <div class="container">
         <p id="nav">
-            <a href="load_json_data_from_server.html">&laquo; Example 2</a>
-            
-                <a href="save_state.html" class="next">Example 4 &raquo;</a>
-            
+            <a href="icon_buttons.html">&laquo; Example 10</a>
         </p>
 
-        <h1>Example 3 - Drag and drop</h1>
+        <h1>Example 11 - Drag and drop with box dragging</h1>
 
-        
+
     <div id="tree1" class='box' data-url="/example_data/"></div>
 
     <p>
-       Let's add drag-and-drop support by setting the option <strong>dragAndDrop</strong> to true.
-       You can now drag tree nodes to another position.
+       Jqtree also supports a different "box" style method of drag and drop.
+	   Let's add this type of drag-and-drop support by setting the option
+	   <strong>dragAndDrop</strong> to 'box'. Additionally you will need styling
+	   that works with 'boxed' items. You can find an example in
+	   <strong>example.css</strong> . You can now drag tree nodes to another position with this box style.
     </p>
-    <p>
-        Other options:
-    </p>
-    <ul>
-        <li>The option <strong>autoOpen</strong> is set to 0 to open the first level of nodes.</li>
-    </ul>
 
     <h3>html</h3>
-<pre><code class="language-markup">&lt;div id="tree1" data-url="/example_data/"&gt;&lt;/div&gt;</code></pre>
+<pre><code class="language-markup">&lt;div id="tree1" data-url="/example_data/"&gt;&lt;/div&gt;
+</code></pre>
 
     <h3>javascript</h3>
 <pre><code class="language-javascript">var $tree = $('#tree1');
 $tree.tree({
-  dragAndDrop: true,
-  autoOpen: 0
+  dragAndDrop: 'box'
 });
 </code></pre>
 
@@ -84,7 +78,7 @@ $tree.tree({
         $(function() {
             var $tree = $('#tree1');
             $tree.tree({
-                dragAndDrop: true,
+                dragAndDrop: 'box',
                 autoOpen: 0
             });
         });

--- a/examples/icon_buttons.html
+++ b/examples/icon_buttons.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../extra/bower_components/prism/themes/prism-okaidia.css">
     <link rel="stylesheet" href="example.css">
     <link rel="stylesheet" href="../jqtree.css">
-    
+
     <link rel="stylesheet" href="../extra/bower_components/fontawesome/css/font-awesome.min.css">
 
 </head>
@@ -17,12 +17,13 @@
     <div class="container">
         <p id="nav">
             <a href="custom_html.html">&laquo; Example 9</a>
-            
+			<a href="drag_and_drop_box.html" class="next">Example 11 &raquo;</a>
+
         </p>
 
         <h1>Example 10 - use icon toggle buttons</h1>
 
-        
+
     <p>
         You can use the <strong>openedIcon</strong> and <strong>closedIcon</strong> options to use html for
         the toggle buttons. You can for example use <a href="http://fortawesome.github.io/Font-Awesome/">Fontawesome icons</a>.

--- a/index.html
+++ b/index.html
@@ -267,6 +267,8 @@ $('#tree1').tree({
                 <li><a href="examples/multiple_select.html">Example 8 - multiple select</a></li>
                 <li><a href="examples/custom_html.html">Example 9 - custom html</a></li>
                 <li><a href="examples/icon_buttons.html">Example 10 - use icon toggle buttons</a></li>
+                <li><a href="examples/drag_and_drop_box.html">Example 11 - drag
+				and drop box style</a></li>
             </ul>
 
             <h4 id="changelog">Changelog</h4>
@@ -372,7 +374,7 @@ $('#tree1').tree({
                 <li>Issue 87: Remove the must_open_parents parameter from the selectNode function</li>
                 <li>Issue 88: selectNode must also work if selectable option is false</li>
                 <li>Issue 89: Clicking in title with img or em does not work</li>
-                <li>Issue 96: Added jqtree_common class to avoid css clashes (thanks to Yaniv Iny)</li> 
+                <li>Issue 96: Added jqtree_common class to avoid css clashes (thanks to Yaniv Iny)</li>
             </ul>
 
             <h4>0.13 (october 10 2012)</h4>
@@ -547,7 +549,7 @@ $('#tree1').tree({data: data});
             </p>
 
 <pre><code class="language-javascript">$('#tree1').tree({
-   dataUrl: '/example_data.json' 
+   dataUrl: '/example_data.json'
 });
 </code></pre>
 

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -242,16 +242,24 @@ class DragAndDropBoxHandler extends DragAndDropHandler
                 index++
                 next = dnd.hit_areas[index]
                 [next, index]
-            [next, index] = increment(this, index)
-            while (next && @dragging_cursor.inCursor(next))
-                [next, index] = increment(this, index)
-            while index < @hit_areas.length
-                if (next.position == Position.INSIDE && @hit_areas[index+1].position == Position.INSIDE)
-                    break
-                if next.position == Position.AFTER
-                    break
-                [next, index] = increment(this, index)
-            return next
+              [next, index] = increment(this, index)
+              while (next && @dragging_cursor.inCursor(next))
+                  [next, index] = increment(this, index)
+              while index < @hit_areas.length
+                  if (next.position == Position.INSIDE && @hit_areas[index+1].position == Position.INSIDE)
+                      break
+                  if next.position == Position.AFTER
+                      break
+                  [next, index] = increment(this, index)
+            if (!next && index >= @hit_areas.length - 1)
+              index = @hit_areas.length - 1
+              area = @hit_areas[index]
+              if area.position == Position.NONE
+                return @hit_areas[index-1]
+              else
+                return area
+            else
+              return next
 
     leavingCursorVertically: (y) ->
         return false unless @dragging_cursor

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -1,1 +1,51 @@
-class DragAndDropBoxHandler
+class DragAndDropBoxHandler extends DragAndDropHandler
+    constructor: (tree_widget) ->
+        @tree_widget = tree_widget
+
+        @hovered_area = null
+        @$ghost = null
+        @hit_areas = []
+        @is_dragging = false
+        @current_item = null
+        @dragging_cursor = null
+
+    mouseStart: (position_info) ->
+
+        offset = $(position_info.target).offset()
+
+        @dragging_cursor = new DraggingCursor(@current_item, Position.NONE)
+
+         #create a drag box element from the element being dragged
+        @drag_element = new DragBoxElement(
+            @current_item.$element
+            position_info.page_x - offset.left,
+            position_info.page_y - offset.top,
+            @tree_widget.element
+        )
+
+        @dragging_cursor.swapGhost()
+
+        @refresh()
+
+        @is_dragging = true
+        return true
+
+class DragBoxElement extends DragElement
+    constructor: (element, offset_x, offset_y, $tree) ->
+        @offset_x = offset_x
+        @offset_y = offset_y
+
+        @$element = $("<div class=\"jqtree-title jqtree-dragging\"></div>")
+        @$element.append($(element).clone())
+
+        @$element.css("position", "absolute")
+        $tree.append(@$element)
+
+class DraggingCursor
+	constructor: (element, position) ->
+        @$element = element.$element
+        height = @$element.height()
+        @$ghost = $('<li style = "height:'+height+'px;" class="jqtree_common jqtree-ghost"></li>')
+
+	swapGhost: ->
+		@$element.replaceWith(@$ghost)

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -35,6 +35,24 @@ class DragAndDropBoxHandler extends DragAndDropHandler
         @previousX = current_x
         @horizontal_options = null
 
+    mouseStop: (position_info) ->
+        if !@hovered_area || @hovered_area.position == Position.NONE
+            @dragging_cursor.unSwapGhost()
+            @tree_widget._refreshElements()
+        else
+            @moveItem(position_info)
+        @clear()
+        @removeHover()
+        @removeDropHint()
+        @removeHitAreas()
+
+        if @current_item
+            @current_item.$element.removeClass('jqtree-moving')
+            @current_item = null
+
+        @is_dragging = false
+        return false
+
     mouseDrag: (position_info) ->
         current_y = position_info.page_y
         current_x = position_info.page_x
@@ -244,8 +262,6 @@ class DragBoxElement extends DragElement
         $tree.append(@$element)
 
 
-
-
 class BoxAreasGenerator extends HitAreasGenerator
     constructor: (tree, current_node, tree_bottom, cursor) ->
         super(tree)
@@ -323,6 +339,9 @@ class DraggingCursor
 
     swapGhost: ->
         @$element.replaceWith(@$ghost)
+
+    unSwapGhost: ->
+        @$ghost.replaceWith(@$element)
 
     setIndex: (index) ->
         @index = index

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -31,18 +31,32 @@ class DragAndDropBoxHandler extends DragAndDropHandler
         @is_dragging = true
         return true
 
+    resetHorizontal: (current_x) ->
+        @previousX = current_x
+        @horizontal_options = null
+
     mouseDrag: (position_info) ->
         current_y = position_info.page_y
         current_x = position_info.page_x
         [horizontal_direction, vertical_direction] = @getCurrentDirections(current_x, current_y)
         @drag_element.move(current_x, current_y)
         leaving = @leavingCursorVertically(current_y)
+        #vertically leaving the cursor takes precedence over horizontal nesting
         if leaving && vertical_direction && leaving == vertical_direction
-
             @hovered_area = @findAreaWhenLeaving(vertical_direction)
+            #we have to be on a hovered element so move and refresh everything
             if (@hovered_area)
                 @dragging_cursor.moveTo(@hovered_area)
                 @refresh()
+                @resetHorizontal(current_x)
+
+        else if horizontal_direction == DragAndDropBoxHandler.RIGHT
+            @rightMove()
+
+        else if horizontal_direction == DragAndDropBoxHandler.LEFT
+            @leftMove()
+            @refresh()
+
 
     getCurrentDirections: (current_x, current_y) ->
         if (@previousY == null)
@@ -67,6 +81,89 @@ class DragAndDropBoxHandler extends DragAndDropHandler
             horizontal_direction = DragAndDropBoxHandler.NEUTRAL
         [horizontal_direction, vertical_direction]
 
+    rightMove: (current_x) ->
+        rightMoveArea = @getRightMoveArea()
+        if rightMoveArea
+            @hovered_area = rightMoveArea
+            if rightMoveArea && rightMoveArea.position == Position.INSIDE
+                @dragging_cursor.bump()
+            else
+                @dragging_cursor.moveTo(@hovered_area)
+
+        return false
+
+    getRightMoveArea: () ->
+        if !@horizontal_options
+            @horizontal_options = @generateHorizontalMoveOptions()
+        #@horizontal_options.print()
+
+        if @horizontal_options.hasRight()
+            right = @horizontal_options.shiftRight()
+            return right
+        return null
+
+    leftMove: () ->
+        leftMoveArea = @getLeftMoveArea()
+        if leftMoveArea
+            @hovered_area = leftMoveArea
+            @dragging_cursor.moveTo(@hovered_area)
+            return true
+        return false
+
+    getLeftMoveArea: () ->
+        if !@horizontal_options
+            @horizontal_options = @generateHorizontalMoveOptions()
+        #@horizontal_options.print()
+        if @horizontal_options.hasLeft()
+            left = @horizontal_options.shiftLeft()
+            return left
+        return null
+
+    generateHorizontalMoveOptions: () ->
+        @refresh
+        options = new HorizontalOptions()
+        [area, index] = @findCursor()
+        #if we are already as nested as far right as possible
+        current = area
+        options.setCurrent(current)
+
+        #get areas to the right
+        index--
+        previous = @hit_areas[index]
+        previousIsFolder = previous.node.hasChildren()
+        previousIsOpen =  previousIsFolder && !previous.node.element.classList.contains('jqtree-closed')
+
+        if previous && previous.position == Position.AFTER && @dragging_cursor.inCursor(previous)
+            #skip over element that is in the same area as the cursor
+            index--
+            previous = @hit_areas[index]
+
+        if previous && !(previousIsFolder && previousIsOpen && previous.position == Position.INSIDE)
+           #the cursor is not the first element in an open tree so it can nest
+            while previous && previous.position == Position.AFTER
+                options.rightPush(previous)
+                index--
+                previous = @hit_areas[index]
+            if previous && previous.position == Position.INSIDE
+                options.rightPush(previous)
+
+        #get areas to left
+        index = @hit_areas.lastIndexOf(current)
+        index++
+        next = @hit_areas[index]
+
+        if next && @dragging_cursor.inCursor(next)
+            #skip over element that is in the same area as the cursor
+            index++
+            next = @hit_areas[index]
+
+        while next && next.position == Position.AFTER
+            index++
+            options.leftPush(next)
+            next = @hit_areas[index++]
+
+        return options
+
     generateHitAreas: ->
         hit_areas_generator = new BoxAreasGenerator(
             @tree_widget.tree,
@@ -76,10 +173,22 @@ class DragAndDropBoxHandler extends DragAndDropHandler
         )
         @hit_areas = hit_areas_generator.generate()
 
-    findAreaWhenLeaving: (direction) ->
-        cursor_area = @findHoveredArea(@getTreeDimensions.left, @dragging_cursor.area().top)
-        index = @hit_areas.lastIndexOf(cursor_area)
+    findCursor: ->
+        index = @dragging_cursor.index
+        area = @hit_areas[index]
+        [area, index]
 
+    clear: ->
+        @drag_element.remove()
+        @drag_element = null
+        @dragging_cursor.remove()
+        @dragging_cursor = null
+        @previousX = null
+        @previousY = null
+        @horizontal_options = null
+
+    findAreaWhenLeaving: (direction) ->
+        [cursor,index] = @findCursor()
         if direction == DragAndDropBoxHandler.UP
             decrement = (dnd, index) ->
                 index--
@@ -87,7 +196,7 @@ class DragAndDropBoxHandler extends DragAndDropHandler
                 [previous,index]
 
             [previous, index] = decrement(this, index)
-            while index > 0 && (previous.position != Position.AFTER || previous.bottom > cursor_area.top)
+            while index > 0 && (previous.position != Position.AFTER || previous.bottom > cursor.top)
                 [previous, index] = decrement(this, index)
             return previous
 
@@ -97,6 +206,8 @@ class DragAndDropBoxHandler extends DragAndDropHandler
                 next = dnd.hit_areas[index]
                 [next, index]
             [next, index] = increment(this, index)
+            if (@dragging_cursor.inCursor(next))
+                [next, index] = increment(this, index)
             while index < @hit_areas.length && next.position != Position.AFTER
                 [next, index] = increment(this, index)
             return next
@@ -133,6 +244,8 @@ class DragBoxElement extends DragElement
         $tree.append(@$element)
 
 
+
+
 class BoxAreasGenerator extends HitAreasGenerator
     constructor: (tree, current_node, tree_bottom, cursor) ->
         super(tree)
@@ -145,8 +258,10 @@ class BoxAreasGenerator extends HitAreasGenerator
         @last_top = 0
 
         @iterate()
-        @addCursor()
-        return @generateHitAreas(@positions)
+
+        hit_areas = @generateHitAreas(@positions)
+        @addCursor(hit_areas)
+        return hit_areas
 
     handleNode: (node, next_node, $element) ->
         top = @getTop($element)
@@ -169,6 +284,17 @@ class BoxAreasGenerator extends HitAreasGenerator
 
         @addPosition(node, Position.AFTER, top)
 
+    handleOpenFolder: (node, $element) ->
+        if node == @current_node
+            # Cannot move inside current item
+            # Stop iterating
+            return false
+
+        @addPosition(node, Position.INSIDE, @getTop($element))
+
+        # Continue iterating
+        return true
+
     handleAfterOpenFolder: (node, next_node, $element) ->
         if node == @current_node.node
             # Cannot move after current item
@@ -176,14 +302,17 @@ class BoxAreasGenerator extends HitAreasGenerator
         else
             @addPosition(node, Position.AFTER, @last_top)
 
-    addCursor: () ->
+    addCursor: (hit_areas) ->
         cursor_area = @cursor.area()
         if cursor_area
-            for i in [0..@positions.length - 1] by 1
-                position = @positions[i]
+            i = 0
+            while i < hit_areas.length
+                position = hit_areas[i]
                 if cursor_area.top < position.top
-                    @positions.splice(i, 0 , @cursor.area())
                     break
+                i++
+            @cursor.index = i
+            hit_areas.splice(i, 0 , cursor_area)
 
 class DraggingCursor
     constructor: (element, position) ->
@@ -195,18 +324,91 @@ class DraggingCursor
     swapGhost: ->
         @$element.replaceWith(@$ghost)
 
+    setIndex: (index) ->
+        @index = index
+
     area: ->
         area = {
             top: @$ghost.offset().top
             node: @node
             position: Position.NONE
+            bottom: @$ghost.offset().top + @$ghost.height()
         }
 
     moveTo: (area) ->
         element = $(area.node.element)
+        if (@bumped)
+            @deBump()
         if area.position is Position.AFTER
             element.after(@$ghost)
         else if area.position is Position.BEFORE
             element.before(@$ghost)
 
+    bump: ->
+        @bumped = true
+        @$ghost.addClass('bumped')
 
+    deBump: ->
+        @bumped = false
+        @$ghost.removeClass('bumped')
+
+    remove: ->
+        @$ghost.remove()
+
+    inCursor: (area) ->
+        offset = @$ghost.offset()
+        area.bottom > offset.top && (offset.left == $(area.node.element).offset().left)
+
+
+
+class HorizontalOptions
+    constructor: () ->
+        @right_arr = []
+        @left_arr = []
+        @current = null
+
+    setCurrent: (area) ->
+        @current = area
+
+    shiftLeft: () ->
+        if @hasLeft
+            new_current_item = @left_arr.shift()
+            @right_arr.unshift(@current)
+            @setCurrent(new_current_item)
+            return new_current_item
+        else
+            return false
+
+    shiftRight: () ->
+        if @hasRight
+            new_current_item = @right_arr.shift()
+            @left_arr.unshift(@current)
+            @setCurrent(new_current_item)
+            return new_current_item
+        else
+            return false
+
+    rightPush: (area) ->
+        @right_arr.push(area)
+
+    leftPush: (area) ->
+        @left_arr.push(area)
+
+    hasLeft: () ->
+        return if (@left_arr.length == 0) then false else true
+
+    hasRight: () ->
+        return if (@right_arr.length == 0) then false else true
+
+    print: () ->
+        for i in [@left_arr.length - 1..0] by -1
+            if i == 0
+                console.log("-1", @left_arr[i]);
+            else
+                console.log("-" + (i-1), @left_arr[i]);
+
+        console.log('Current', @current)
+
+        for i in [0..@right_arr.length] by 1
+            if @right_arr[i]
+                console.log("+"+ (i + 1), @right_arr[i])

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -1,0 +1,1 @@
+class DragAndDropBoxHandler

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -413,6 +413,7 @@ class DraggingCursor
         @$ghost.remove()
 
     inCursor: (area) ->
+        return false unless area
         offset = @$ghost.offset()
         top = offset.top
         bottom = @$ghost.height() + top

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -1,13 +1,14 @@
 class DragAndDropBoxHandler extends DragAndDropHandler
     constructor: (tree_widget) ->
         @tree_widget = tree_widget
-
         @hovered_area = null
         @$ghost = null
         @hit_areas = []
         @is_dragging = false
         @current_item = null
         @dragging_cursor = null
+        @previousY = null
+        @previousX = null
 
     mouseStart: (position_info) ->
 
@@ -30,6 +31,36 @@ class DragAndDropBoxHandler extends DragAndDropHandler
         @is_dragging = true
         return true
 
+    mouseDrag: (position_info) ->
+        current_y = position_info.page_y
+        current_x = position_info.page_x
+        [horizontal_direction, vertical_direction] = @getCurrentDirections(current_x, current_y)
+        @drag_element.move(current_x, current_y)
+
+    getCurrentDirections: (current_x, current_y) ->
+        if (@previousY == null)
+            vertical_direction = DragAndDropBoxHandler.NEUTRAL
+        else if (@previousY > current_y)
+            vertical_direction = DragAndDropBoxHandler.UP
+        else if (@previousY < current_y)
+            vertical_direction = DragAndDropBoxHandler.DOWN
+        else
+            horizontal_direction = DragAndDropBoxHandler.NEUTRAL
+        @previousY = current_y
+
+        if (@previousX == null)
+            horizontal_direction = DragAndDropBoxHandler.NEUTRAL
+            @previousX = current_x
+        else if (current_x > (@previousX + 20))
+            @previousX = current_x
+            horizontal_direction = DragAndDropBoxHandler.RIGHT
+        else if (current_x < (@previousX - 20))
+            @previousX = current_x
+            horizontal_direction = DragAndDropBoxHandler.LEFT
+        else
+            horizontal_direction = DragAndDropBoxHandler.NEUTRAL
+        [horizontal_direction, vertical_direction]
+
     generateHitAreas: ->
         hit_areas_generator = new BoxAreasGenerator(
             @tree_widget.tree,
@@ -42,6 +73,12 @@ class DragAndDropBoxHandler extends DragAndDropHandler
     refresh: ->
         @removeHitAreas()
         @generateHitAreas()
+
+DragAndDropBoxHandler.UP = 1
+DragAndDropBoxHandler.DOWN = -1
+DragAndDropBoxHandler.RIGHT = 1
+DragAndDropBoxHandler.LEFT = -1
+DragAndDropBoxHandler.NEUTRAL = 0
 
 class DragBoxElement extends DragElement
     constructor: (element, offset_x, offset_y, $tree) ->

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -152,7 +152,7 @@ class DragAndDropBoxHandler extends DragAndDropHandler
         return null
 
     generateHorizontalMoveOptions: () ->
-        @refresh
+        @refresh()
         options = new HorizontalOptions()
 
         [area, index] = @findCursor()
@@ -287,8 +287,9 @@ class DragBoxElement extends DragElement
 
 
 class BoxAreasGenerator extends HitAreasGenerator
-    constructor: (tree, current_node, tree_bottom, cursor) ->
-        super(tree)
+    constructor: (tree, current_node, tree_bottom, cursor, group_size_max) ->
+        group_size_max ?= 12
+        super(tree, current_node, tree_bottom, group_size_max)
         @cursor = cursor
         @current_node = current_node
         @tree_bottom = tree_bottom

--- a/src/drag_and_drop_box_handler.coffee
+++ b/src/drag_and_drop_box_handler.coffee
@@ -79,7 +79,7 @@ class DragAndDropBoxHandler extends DragAndDropHandler
             @hovered_area = @findAreaWhenLeaving(vertical_direction)
             #we have to be on a hovered element so move and refresh everything
             if (@hovered_area)
-                @dragging_cursor.moveTo(@hovered_area)
+                @dragging_cursor.moveTo(@hovered_area, @hit_areas.lastIndexOf(@hovered_area))
                 @refresh()
                 @resetHorizontal(current_x)
 
@@ -390,8 +390,9 @@ class DraggingCursor
             bottom: @$ghost.offset().top + @$ghost.height()
         }
 
-    moveTo: (area) ->
+    moveTo: (area, index) ->
         element = $(area.node.element)
+        @setIndex(index) if index
         if (@bumped)
             @deBump()
         if area.position is Position.AFTER

--- a/src/drag_and_drop_handler.coffee
+++ b/src/drag_and_drop_handler.coffee
@@ -112,7 +112,7 @@ class DragAndDropHandler
     generateHitAreas: ->
         hit_areas_generator = new HitAreasGenerator(
             @tree_widget.tree,
-            @current_item.node,            
+            @current_item.node,
             @getTreeDimensions().bottom
         )
         @hit_areas = hit_areas_generator.generate()
@@ -239,7 +239,7 @@ class VisibleNodeIterator
                 (node.is_open or not node.element) and node.hasChildren()
             )
 
-            if node.element                
+            if node.element
                 $element = $(node.element)
 
                 if not $element.is(':visible')
@@ -290,9 +290,9 @@ class VisibleNodeIterator
 
 
 class HitAreasGenerator extends VisibleNodeIterator
-    constructor: (tree, current_node, tree_bottom) ->
+    constructor: (tree, current_node, tree_bottom, group_size_max) ->
         super(tree)
-
+        @group_size_max = group_size_max ? group_size_max : 4
         @current_node = current_node
         @tree_bottom = tree_bottom
 
@@ -311,7 +311,7 @@ class HitAreasGenerator extends VisibleNodeIterator
         area = {
             top: top
             node: node
-            position: position            
+            position: position
         }
 
         @positions.push(area)
@@ -406,7 +406,7 @@ class HitAreasGenerator extends VisibleNodeIterator
 
     generateHitAreasForGroup: (hit_areas, positions_in_group, top, bottom) ->
         # limit positions in group
-        position_count = Math.min(positions_in_group.length, 4)
+        position_count = Math.min(positions_in_group.length, @group_size_max)
 
         area_height = Math.round((bottom - top) / position_count)
         area_top = top

--- a/src/node.coffee
+++ b/src/node.coffee
@@ -366,4 +366,24 @@ class Node
             else
                 return null                
 
+    getNodesByProperty: (key, value) ->
+        return @filter(
+            (node) ->
+                return node[key] == value
+        )
+
+    filter: (f) ->
+        result = []
+
+        @iterate(
+            (node) ->
+                if f(node)
+                    result.push(node)
+
+                return true
+        )
+
+        return result
+
+
 @Tree.Node = Node

--- a/src/tree.jquery.coffee
+++ b/src/tree.jquery.coffee
@@ -19,7 +19,7 @@ class JqTreeWidget extends MouseWidget
     defaults:
         autoOpen: false  # true / false / int (open n levels starting at 0)
         saveState: false  # true / false / string (cookie name)
-        dragAndDrop: false
+        dragAndDrop: false # true / false / string (drag and drop type: 'box' or 'line')
         selectable: true
         useContextMenu: true
         onCanSelectNode: null
@@ -388,7 +388,9 @@ class JqTreeWidget extends MouseWidget
         if SelectNodeHandler?
             @select_node_handler = new SelectNodeHandler(this)
 
-        if DragAndDropHandler?
+        if DragAndDropBoxHandler? && @options.dragAndDrop == 'box'
+            @dnd_handler = new DragAndDropBoxHandler(this)
+        else if DragAndDropHandler?
             @dnd_handler = new DragAndDropHandler(this)
         else
             @options.dragAndDrop = false

--- a/src/tree.jquery.coffee
+++ b/src/tree.jquery.coffee
@@ -45,7 +45,7 @@ class JqTreeWidget extends MouseWidget
             @closeNode(node, slide)
         else
             @openNode(node, slide)
-    
+
     getTree: ->
         return @tree
 
@@ -70,7 +70,7 @@ class JqTreeWidget extends MouseWidget
 
         saveState = =>
             if @options.saveState
-                @save_state_handler.saveState()            
+                @save_state_handler.saveState()
 
         if not node
             # Called with empty node -> deselect current node
@@ -145,7 +145,7 @@ class JqTreeWidget extends MouseWidget
                 url_info.method = 'get'
 
         handeLoadData = (data) =>
-            removeLoadingClass()                
+            removeLoadingClass()
             @_loadData(data, parent_node)
 
             if on_finished and $.isFunction(on_finished)
@@ -277,8 +277,8 @@ class JqTreeWidget extends MouseWidget
 
     addParentNode: (new_node_info, existing_node) ->
         new_node = existing_node.addParent(new_node_info)
-        @_refreshElements(new_node.parent)  
-        return new_node    
+        @_refreshElements(new_node.parent)
+        return new_node
 
     removeNode: (node) ->
         parent = node.parent
@@ -305,7 +305,7 @@ class JqTreeWidget extends MouseWidget
             @_refreshElements(parent_node.parent)
 
         return node
- 
+
     prependNode: (new_node_info, parent_node) ->
         if not parent_node
             parent_node = @tree
@@ -637,7 +637,7 @@ class JqTreeWidget extends MouseWidget
     _deselectCurrentNode: ->
         node = @getSelectedNode()
         if node
-            @removeFromSelection(node)        
+            @removeFromSelection(node)
 
 SimpleWidget.register(JqTreeWidget, 'tree')
 
@@ -697,7 +697,7 @@ class FolderElement extends NodeElement
                 @getUl().slideDown('fast', doOpen)
             else
                 @getUl().show()
-                doOpen()                
+                doOpen()
 
     close: (slide=true) ->
         if @node.is_open
@@ -717,7 +717,7 @@ class FolderElement extends NodeElement
             else
                 @getUl().hide()
                 doClose()
-                
+
     getButton: ->
         return @$element.children('.jqtree-element').find('a.jqtree-toggler')
 

--- a/test/test.js
+++ b/test/test.js
@@ -1811,6 +1811,16 @@ test('getNextSibling', function() {
     equal(tree.getNextSibling(), null);
 });
 
+test('getNodesByProperty', function() {
+    var tree = new Tree.Node(null, true);
+    tree.loadFromData(example_data);
+
+    nodes = tree.getNodesByProperty('name', 'child1');
+
+    equal(nodes.length, 1);
+    equal(nodes[0].name, 'child1');
+});
+
 
 module('util');
 

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -3096,7 +3096,7 @@ limitations under the License.
       if (leaving && vertical_direction && leaving === vertical_direction) {
         this.hovered_area = this.findAreaWhenLeaving(vertical_direction);
         if (this.hovered_area) {
-          this.dragging_cursor.moveTo(this.hovered_area);
+          this.dragging_cursor.moveTo(this.hovered_area, this.hit_areas.lastIndexOf(this.hovered_area));
           this.refresh();
           return this.resetHorizontal(current_x);
         }
@@ -3468,9 +3468,12 @@ limitations under the License.
       };
     };
 
-    DraggingCursor.prototype.moveTo = function(area) {
+    DraggingCursor.prototype.moveTo = function(area, index) {
       var element;
       element = $(area.node.element);
+      if (index) {
+        this.setIndex(index);
+      }
       if (this.bumped) {
         this.deBump();
       }

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -3245,7 +3245,7 @@ limitations under the License.
     };
 
     DragAndDropBoxHandler.prototype.findAreaWhenLeaving = function(direction) {
-      var cursor, decrement, increment, index, next, previous, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
+      var area, cursor, decrement, increment, index, next, previous, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
       _ref = this.findCursor(), cursor = _ref[0], index = _ref[1];
       if (direction === DragAndDropBoxHandler.UP) {
         decrement = function(dnd, index) {
@@ -3287,7 +3287,17 @@ limitations under the License.
           }
           _ref6 = increment(this, index), next = _ref6[0], index = _ref6[1];
         }
-        return next;
+        if (!next && index >= this.hit_areas.length - 1) {
+          index = this.hit_areas.length - 1;
+          area = this.hit_areas[index];
+          if (area.position === Position.NONE) {
+            return this.hit_areas[index - 1];
+          } else {
+            return area;
+          }
+        } else {
+          return next;
+        }
       }
     };
 

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -766,6 +766,24 @@ limitations under the License.
       }
     };
 
+    Node.prototype.getNodesByProperty = function(key, value) {
+      return this.filter(function(node) {
+        return node[key] === value;
+      });
+    };
+
+    Node.prototype.filter = function(f) {
+      var result;
+      result = [];
+      this.iterate(function(node) {
+        if (f(node)) {
+          result.push(node);
+        }
+        return true;
+      });
+      return result;
+    };
+
     return Node;
 
   })();

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -406,7 +406,7 @@ limitations under the License.
 
     /*
     Create tree from data.
-    
+
     Structure of data is:
     [
         {
@@ -439,7 +439,7 @@ limitations under the License.
 
     /*
     Add child.
-    
+
     tree.addChild(
         new Node('child1')
     );
@@ -453,7 +453,7 @@ limitations under the License.
 
     /*
     Add child at position. Index starts at 0.
-    
+
     tree.addChildAtPosition(
         new Node('abc'),
         1
@@ -474,7 +474,7 @@ limitations under the License.
 
     /*
     Remove child. This also removes the children of the node.
-    
+
     tree.removeChild(tree.children[0]);
      */
 
@@ -491,7 +491,7 @@ limitations under the License.
 
     /*
     Get child index.
-    
+
     var index = getChildIndex(node);
      */
 
@@ -502,7 +502,7 @@ limitations under the License.
 
     /*
     Does the tree have children?
-    
+
     if (tree.hasChildren()) {
         //
     }
@@ -519,15 +519,15 @@ limitations under the License.
 
     /*
     Iterate over all the nodes in the tree.
-    
+
     Calls callback with (node, level).
-    
+
     The callback must return true to continue the iteration on current node.
-    
+
     tree.iterate(
         function(node, level) {
            console.log(node.name);
-    
+
            // stop iteration after level 2
            return (level <= 2);
         }
@@ -559,9 +559,9 @@ limitations under the License.
 
     /*
     Move node relative to another node.
-    
+
     Argument position: Position.BEFORE, Position.AFTER or Position.Inside
-    
+
     // move node1 after node2
     tree.moveNode(node1, node2, Position.AFTER);
      */
@@ -975,13 +975,13 @@ limitations under the License.
 
   /*
   Copyright 2013 Marco Braak
-  
+
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
       http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -3123,16 +3123,17 @@ limitations under the License.
     };
 
     DragAndDropBoxHandler.prototype.mouseDrag = function(position_info) {
-      var current_x, current_y, horizontal_direction, leaving, vertical_direction, _ref;
+      var current_x, current_y, horizontal_direction, leaving, verticalArea, vertical_direction, _ref;
       current_y = position_info.page_y;
       current_x = position_info.page_x;
       _ref = this.getCurrentDirections(current_x, current_y), horizontal_direction = _ref[0], vertical_direction = _ref[1];
       this.drag_element.move(current_x, current_y);
       leaving = this.leavingCursorVertically(current_y);
-      if (leaving && vertical_direction && leaving === vertical_direction) {
-        this.hovered_area = this.findAreaWhenLeaving(vertical_direction);
-        if (this.hovered_area) {
-          this.dragging_cursor.moveTo(this.hovered_area, this.hit_areas.lastIndexOf(this.hovered_area));
+      if (vertical_direction && leaving && leaving === vertical_direction) {
+        verticalArea = this.findAreaWhenLeaving(vertical_direction);
+        if (verticalArea) {
+          this.hovered_area = verticalArea;
+          this.dragging_cursor.moveTo(this.hovered_area);
           this.refresh();
           return this.resetHorizontal(current_x);
         }
@@ -3171,7 +3172,7 @@ limitations under the License.
     DragAndDropBoxHandler.prototype.rightMove = function(current_x) {
       var rightMoveArea;
       rightMoveArea = this.getRightMoveArea();
-      if (rightMoveArea) {
+      if (rightMoveArea && this.canMoveToArea(rightMoveArea)) {
         this.hovered_area = rightMoveArea;
         if (rightMoveArea && rightMoveArea.position === Position.INSIDE) {
           this.dragging_cursor.bump();
@@ -3197,7 +3198,7 @@ limitations under the License.
     DragAndDropBoxHandler.prototype.leftMove = function() {
       var leftMoveArea;
       leftMoveArea = this.getLeftMoveArea();
-      if (leftMoveArea) {
+      if (leftMoveArea && this.canMoveToArea(leftMoveArea)) {
         this.hovered_area = leftMoveArea;
         this.dragging_cursor.moveTo(this.hovered_area);
         return true;
@@ -3281,7 +3282,7 @@ limitations under the License.
     };
 
     DragAndDropBoxHandler.prototype.findAreaWhenLeaving = function(direction) {
-      var area, cursor, decrement, increment, index, next, previous, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
+      var area, cursor, decrement, increment, index, next, previous, previous_parent, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
       _ref = this.findCursor(), cursor = _ref[0], index = _ref[1];
       if (direction === DragAndDropBoxHandler.UP) {
         decrement = function(dnd, index) {
@@ -3292,11 +3293,14 @@ limitations under the License.
         };
         _ref1 = decrement(this, index), previous = _ref1[0], index = _ref1[1];
         while (index > 0) {
-          if (previous.position === Position.INSIDE && this.hit_areas[index - 1].position === Position.INSIDE) {
-            _ref2 = decrement(this, index), previous = _ref2[0], index = _ref2[1];
-            break;
+          if (previous.position === Position.INSIDE) {
+            previous_parent = this.hit_areas[index - 1];
+            if (previous_parent.position === Position.INSIDE && this.canMoveToArea(this.hit_areas[index - 1])) {
+              _ref2 = decrement(this, index), previous = _ref2[0], index = _ref2[1];
+              break;
+            }
           }
-          if (previous.position === Position.AFTER && previous.bottom < cursor.top) {
+          if (previous.position === Position.AFTER && previous.bottom < cursor.top && this.canMoveToArea(previous)) {
             break;
           }
           _ref3 = decrement(this, index), previous = _ref3[0], index = _ref3[1];
@@ -3315,11 +3319,13 @@ limitations under the License.
           _ref5 = increment(this, index), next = _ref5[0], index = _ref5[1];
         }
         while (index < this.hit_areas.length) {
-          if (next.position === Position.INSIDE && this.hit_areas[index + 1].position === Position.INSIDE) {
-            break;
-          }
-          if (next.position === Position.AFTER) {
-            break;
+          if (this.canMoveToArea(next)) {
+            if (next.position === Position.INSIDE && this.hit_areas[index + 1].position === Position.INSIDE) {
+              break;
+            }
+            if (next.position === Position.AFTER) {
+              break;
+            }
           }
           _ref6 = increment(this, index), next = _ref6[0], index = _ref6[1];
         }
@@ -3500,10 +3506,6 @@ limitations under the License.
       return this.$ghost.replaceWith(this.$element);
     };
 
-    DraggingCursor.prototype.setIndex = function(index) {
-      return this.index = index;
-    };
-
     DraggingCursor.prototype.area = function() {
       var area;
       return area = {
@@ -3514,12 +3516,9 @@ limitations under the License.
       };
     };
 
-    DraggingCursor.prototype.moveTo = function(area, index) {
+    DraggingCursor.prototype.moveTo = function(area) {
       var element;
       element = $(area.node.element);
-      if (index) {
-        this.setIndex(index);
-      }
       if (this.bumped) {
         this.deBump();
       }

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -17,7 +17,7 @@ limitations under the License.
  */
 
 (function() {
-  var $, BorderDropHint, DragAndDropHandler, DragElement, ElementsRenderer, FolderElement, GhostDropHint, HitAreasGenerator, JqTreeWidget, KeyHandler, MouseWidget, Node, NodeElement, Position, SaveStateHandler, ScrollHandler, SelectNodeHandler, SimpleWidget, VisibleNodeIterator, get_json_stringify_function, html_escape, indexOf, _indexOf,
+  var $, BorderDropHint, DragAndDropBoxHandler, DragAndDropHandler, DragElement, ElementsRenderer, FolderElement, GhostDropHint, HitAreasGenerator, JqTreeWidget, KeyHandler, MouseWidget, Node, NodeElement, Position, SaveStateHandler, ScrollHandler, SelectNodeHandler, SimpleWidget, VisibleNodeIterator, get_json_stringify_function, html_escape, indexOf, _indexOf,
     __slice = [].slice,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
@@ -3006,6 +3006,13 @@ limitations under the License.
     };
 
     return KeyHandler;
+
+  })();
+
+  DragAndDropBoxHandler = (function() {
+    function DragAndDropBoxHandler() {}
+
+    return DragAndDropBoxHandler;
 
   })();
 

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -1450,7 +1450,9 @@ limitations under the License.
       if (typeof SelectNodeHandler !== "undefined" && SelectNodeHandler !== null) {
         this.select_node_handler = new SelectNodeHandler(this);
       }
-      if (typeof DragAndDropHandler !== "undefined" && DragAndDropHandler !== null) {
+      if ((typeof DragAndDropBoxHandler !== "undefined" && DragAndDropBoxHandler !== null) && this.options.dragAndDrop === 'box') {
+        this.dnd_handler = new DragAndDropBoxHandler(this);
+      } else if (typeof DragAndDropHandler !== "undefined" && DragAndDropHandler !== null) {
         this.dnd_handler = new DragAndDropHandler(this);
       } else {
         this.options.dragAndDrop = false;

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -3020,6 +3020,8 @@ limitations under the License.
       this.is_dragging = false;
       this.current_item = null;
       this.dragging_cursor = null;
+      this.previousY = null;
+      this.previousX = null;
     }
 
     DragAndDropBoxHandler.prototype.mouseStart = function(position_info) {
@@ -3031,6 +3033,41 @@ limitations under the License.
       this.refresh();
       this.is_dragging = true;
       return true;
+    };
+
+    DragAndDropBoxHandler.prototype.mouseDrag = function(position_info) {
+      var current_x, current_y, horizontal_direction, vertical_direction, _ref;
+      current_y = position_info.page_y;
+      current_x = position_info.page_x;
+      _ref = this.getCurrentDirections(current_x, current_y), horizontal_direction = _ref[0], vertical_direction = _ref[1];
+      return this.drag_element.move(current_x, current_y);
+    };
+
+    DragAndDropBoxHandler.prototype.getCurrentDirections = function(current_x, current_y) {
+      var horizontal_direction, vertical_direction;
+      if (this.previousY === null) {
+        vertical_direction = DragAndDropBoxHandler.NEUTRAL;
+      } else if (this.previousY > current_y) {
+        vertical_direction = DragAndDropBoxHandler.UP;
+      } else if (this.previousY < current_y) {
+        vertical_direction = DragAndDropBoxHandler.DOWN;
+      } else {
+        horizontal_direction = DragAndDropBoxHandler.NEUTRAL;
+      }
+      this.previousY = current_y;
+      if (this.previousX === null) {
+        horizontal_direction = DragAndDropBoxHandler.NEUTRAL;
+        this.previousX = current_x;
+      } else if (current_x > (this.previousX + 20)) {
+        this.previousX = current_x;
+        horizontal_direction = DragAndDropBoxHandler.RIGHT;
+      } else if (current_x < (this.previousX - 20)) {
+        this.previousX = current_x;
+        horizontal_direction = DragAndDropBoxHandler.LEFT;
+      } else {
+        horizontal_direction = DragAndDropBoxHandler.NEUTRAL;
+      }
+      return [horizontal_direction, vertical_direction];
     };
 
     DragAndDropBoxHandler.prototype.generateHitAreas = function() {
@@ -3047,6 +3084,16 @@ limitations under the License.
     return DragAndDropBoxHandler;
 
   })(DragAndDropHandler);
+
+  DragAndDropBoxHandler.UP = 1;
+
+  DragAndDropBoxHandler.DOWN = -1;
+
+  DragAndDropBoxHandler.RIGHT = 1;
+
+  DragAndDropBoxHandler.LEFT = -1;
+
+  DragAndDropBoxHandler.NEUTRAL = 0;
 
   DragBoxElement = (function(_super) {
     __extends(DragBoxElement, _super);

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -3351,52 +3351,6 @@ limitations under the License.
       this.tree_bottom = tree_bottom;
     }
 
-    BoxAreasGenerator.prototype.iterate = function() {
-      var is_first_node, _iterateNode;
-      is_first_node = true;
-      _iterateNode = (function(_this) {
-        return function(node, next_node, depth) {
-          var $element, child, children_length, i, must_iterate_inside, _i, _len, _ref;
-          must_iterate_inside = (node.is_open || !node.element) && node.hasChildren();
-          if (node.element) {
-            $element = $(node.element);
-            if (!$element.is(':visible')) {
-              return;
-            }
-            if (is_first_node) {
-              _this.handleFirstNode(node, $element, depth);
-              is_first_node = false;
-            }
-            if (!node.hasChildren()) {
-              _this.handleNode(node, next_node, $element, depth);
-            } else if (node.is_open) {
-              if (!_this.handleOpenFolder(node, $element, depth)) {
-                must_iterate_inside = false;
-              }
-            } else {
-              _this.handleClosedFolder(node, next_node, $element, depth);
-            }
-          }
-          if (must_iterate_inside) {
-            children_length = node.children.length;
-            _ref = node.children;
-            for (i = _i = 0, _len = _ref.length; _i < _len; i = ++_i) {
-              child = _ref[i];
-              if (i === (children_length - 1)) {
-                _iterateNode(node.children[i], null, depth + 1);
-              } else {
-                _iterateNode(node.children[i], node.children[i + 1], depth + 1);
-              }
-            }
-            if (node.is_open) {
-              return _this.handleAfterOpenFolder(node, next_node, $element, depth);
-            }
-          }
-        };
-      })(this);
-      return _iterateNode(this.tree, null, 0);
-    };
-
     BoxAreasGenerator.prototype.generate = function() {
       var hit_areas;
       this.positions = [];
@@ -3407,53 +3361,52 @@ limitations under the License.
       return hit_areas;
     };
 
-    BoxAreasGenerator.prototype.addPosition = function(node, position, top, depth) {
+    BoxAreasGenerator.prototype.addPosition = function(node, position, top) {
       var area;
       area = {
         top: top,
         node: node,
-        position: position,
-        depth: depth
+        position: position
       };
       this.positions.push(area);
       return this.last_top = top;
     };
 
-    BoxAreasGenerator.prototype.handleNode = function(node, next_node, $element, depth) {
+    BoxAreasGenerator.prototype.handleNode = function(node, next_node, $element) {
       var top;
       top = this.getTop($element);
       if (node === this.current_node) {
-        return this.addPosition(node, Position.NONE, top, depth);
+        return this.addPosition(node, Position.NONE, top);
       } else {
-        this.addPosition(node, Position.INSIDE, top, depth);
-        return this.addPosition(node, Position.AFTER, top, depth);
+        this.addPosition(node, Position.INSIDE, top);
+        return this.addPosition(node, Position.AFTER, top);
       }
     };
 
-    BoxAreasGenerator.prototype.handleClosedFolder = function(node, next_node, $element, depth) {
+    BoxAreasGenerator.prototype.handleClosedFolder = function(node, next_node, $element) {
       var top;
       top = this.getTop($element);
       if (node === this.current_node) {
-        this.addPosition(node, Position.NONE, top, depth);
+        this.addPosition(node, Position.NONE, top);
       } else {
-        this.addPosition(node, Position.INSIDE, top, depth);
+        this.addPosition(node, Position.INSIDE, top);
       }
-      return this.addPosition(node, Position.AFTER, top, depth);
+      return this.addPosition(node, Position.AFTER, top);
     };
 
-    BoxAreasGenerator.prototype.handleOpenFolder = function(node, $element, depth) {
+    BoxAreasGenerator.prototype.handleOpenFolder = function(node, $element) {
       if (node === this.current_node) {
         return false;
       }
-      this.addPosition(node, Position.INSIDE, this.getTop($element), depth);
+      this.addPosition(node, Position.INSIDE, this.getTop($element));
       return true;
     };
 
-    BoxAreasGenerator.prototype.handleAfterOpenFolder = function(node, next_node, $element, depth) {
+    BoxAreasGenerator.prototype.handleAfterOpenFolder = function(node, next_node, $element) {
       if (node === this.current_node.node) {
-        return this.addPosition(node, Position.NONE, this.last_top, depth);
+        return this.addPosition(node, Position.NONE, this.last_top);
       } else {
-        return this.addPosition(node, Position.AFTER, this.last_top, depth);
+        return this.addPosition(node, Position.AFTER, this.last_top);
       }
     };
 
@@ -3472,27 +3425,6 @@ limitations under the License.
         this.cursor.index = i;
         return hit_areas.splice(i, 0, cursor_area);
       }
-    };
-
-    BoxAreasGenerator.prototype.generateHitAreasForGroup = function(hit_areas, positions_in_group, top, bottom) {
-      var area_height, area_top, i, position, position_count;
-      position_count = Math.min(positions_in_group.length, 4);
-      area_height = Math.round((bottom - top) / position_count);
-      area_top = top;
-      i = 0;
-      while (i < position_count) {
-        position = positions_in_group[i];
-        hit_areas.push({
-          top: area_top,
-          bottom: area_top + area_height,
-          node: position.node,
-          position: position.position,
-          depth: position.depth
-        });
-        area_top += area_height;
-        i += 1;
-      }
-      return null;
     };
 
     return BoxAreasGenerator;

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -3494,6 +3494,9 @@ limitations under the License.
 
     DraggingCursor.prototype.inCursor = function(area) {
       var bottom, left, offset, top;
+      if (!area) {
+        return false;
+      }
       offset = this.$ghost.offset();
       top = offset.top;
       bottom = this.$ghost.height() + top;

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -2523,8 +2523,11 @@ limitations under the License.
   HitAreasGenerator = (function(_super) {
     __extends(HitAreasGenerator, _super);
 
-    function HitAreasGenerator(tree, current_node, tree_bottom) {
+    function HitAreasGenerator(tree, current_node, tree_bottom, group_size_max) {
       HitAreasGenerator.__super__.constructor.call(this, tree);
+      this.group_size_max = group_size_max != null ? group_size_max : {
+        group_size_max: 4
+      };
       this.current_node = current_node;
       this.tree_bottom = tree_bottom;
     }
@@ -2625,7 +2628,7 @@ limitations under the License.
 
     HitAreasGenerator.prototype.generateHitAreasForGroup = function(hit_areas, positions_in_group, top, bottom) {
       var area_height, area_top, i, position, position_count;
-      position_count = Math.min(positions_in_group.length, 4);
+      position_count = Math.min(positions_in_group.length, this.group_size_max);
       area_height = Math.round((bottom - top) / position_count);
       area_top = top;
       i = 0;
@@ -3180,7 +3183,7 @@ limitations under the License.
 
     DragAndDropBoxHandler.prototype.generateHorizontalMoveOptions = function() {
       var area, current, index, next, options, previous, previousIsFolder, previousIsOpen, _ref;
-      this.refresh;
+      this.refresh();
       options = new HorizontalOptions();
       _ref = this.findCursor(), area = _ref[0], index = _ref[1];
       current = area;
@@ -3344,8 +3347,11 @@ limitations under the License.
   BoxAreasGenerator = (function(_super) {
     __extends(BoxAreasGenerator, _super);
 
-    function BoxAreasGenerator(tree, current_node, tree_bottom, cursor) {
-      BoxAreasGenerator.__super__.constructor.call(this, tree);
+    function BoxAreasGenerator(tree, current_node, tree_bottom, cursor, group_size_max) {
+      if (group_size_max == null) {
+        group_size_max = 12;
+      }
+      BoxAreasGenerator.__super__.constructor.call(this, tree, current_node, tree_bottom, group_size_max);
       this.cursor = cursor;
       this.current_node = current_node;
       this.tree_bottom = tree_bottom;

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -3040,6 +3040,25 @@ limitations under the License.
       return this.horizontal_options = null;
     };
 
+    DragAndDropBoxHandler.prototype.mouseStop = function(position_info) {
+      if (!this.hovered_area || this.hovered_area.position === Position.NONE) {
+        this.dragging_cursor.unSwapGhost();
+        this.tree_widget._refreshElements();
+      } else {
+        this.moveItem(position_info);
+      }
+      this.clear();
+      this.removeHover();
+      this.removeDropHint();
+      this.removeHitAreas();
+      if (this.current_item) {
+        this.current_item.$element.removeClass('jqtree-moving');
+        this.current_item = null;
+      }
+      this.is_dragging = false;
+      return false;
+    };
+
     DragAndDropBoxHandler.prototype.mouseDrag = function(position_info) {
       var current_x, current_y, horizontal_direction, leaving, vertical_direction, _ref;
       current_y = position_info.page_y;
@@ -3376,6 +3395,10 @@ limitations under the License.
 
     DraggingCursor.prototype.swapGhost = function() {
       return this.$element.replaceWith(this.$ghost);
+    };
+
+    DraggingCursor.prototype.unSwapGhost = function() {
+      return this.$ghost.replaceWith(this.$element);
     };
 
     DraggingCursor.prototype.setIndex = function(index) {

--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -17,7 +17,7 @@ limitations under the License.
  */
 
 (function() {
-  var $, BorderDropHint, DragAndDropBoxHandler, DragAndDropHandler, DragElement, ElementsRenderer, FolderElement, GhostDropHint, HitAreasGenerator, JqTreeWidget, KeyHandler, MouseWidget, Node, NodeElement, Position, SaveStateHandler, ScrollHandler, SelectNodeHandler, SimpleWidget, VisibleNodeIterator, get_json_stringify_function, html_escape, indexOf, _indexOf,
+  var $, BorderDropHint, DragAndDropBoxHandler, DragAndDropHandler, DragBoxElement, DragElement, DraggingCursor, ElementsRenderer, FolderElement, GhostDropHint, HitAreasGenerator, JqTreeWidget, KeyHandler, MouseWidget, Node, NodeElement, Position, SaveStateHandler, ScrollHandler, SelectNodeHandler, SimpleWidget, VisibleNodeIterator, get_json_stringify_function, html_escape, indexOf, _indexOf,
     __slice = [].slice,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
@@ -3009,10 +3009,63 @@ limitations under the License.
 
   })();
 
-  DragAndDropBoxHandler = (function() {
-    function DragAndDropBoxHandler() {}
+  DragAndDropBoxHandler = (function(_super) {
+    __extends(DragAndDropBoxHandler, _super);
+
+    function DragAndDropBoxHandler(tree_widget) {
+      this.tree_widget = tree_widget;
+      this.hovered_area = null;
+      this.$ghost = null;
+      this.hit_areas = [];
+      this.is_dragging = false;
+      this.current_item = null;
+      this.dragging_cursor = null;
+    }
+
+    DragAndDropBoxHandler.prototype.mouseStart = function(position_info) {
+      var offset;
+      offset = $(position_info.target).offset();
+      this.dragging_cursor = new DraggingCursor(this.current_item, Position.NONE);
+      this.drag_element = new DragBoxElement(this.current_item.$element, position_info.page_x - offset.left, position_info.page_y - offset.top, this.tree_widget.element);
+      this.dragging_cursor.swapGhost();
+      this.refresh();
+      this.is_dragging = true;
+      return true;
+    };
 
     return DragAndDropBoxHandler;
+
+  })(DragAndDropHandler);
+
+  DragBoxElement = (function(_super) {
+    __extends(DragBoxElement, _super);
+
+    function DragBoxElement(element, offset_x, offset_y, $tree) {
+      this.offset_x = offset_x;
+      this.offset_y = offset_y;
+      this.$element = $("<div class=\"jqtree-title jqtree-dragging\"></div>");
+      this.$element.append($(element).clone());
+      this.$element.css("position", "absolute");
+      $tree.append(this.$element);
+    }
+
+    return DragBoxElement;
+
+  })(DragElement);
+
+  DraggingCursor = (function() {
+    function DraggingCursor(element, position) {
+      var height;
+      this.$element = element.$element;
+      height = this.$element.height();
+      this.$ghost = $('<li style = "height:' + height + 'px;" class="jqtree_common jqtree-ghost"></li>');
+    }
+
+    DraggingCursor.prototype.swapGhost = function() {
+      return this.$element.replaceWith(this.$ghost);
+    };
+
+    return DraggingCursor;
 
   })();
 


### PR DESCRIPTION
This pull request adds a new drag and drop style to jqtree, my collaborator (@kennykaye) and I refer to this as box style dragging.  We think this change makes jqtree even more versatile and adds support for a dragging style that is popular elsewhere ( e.g. this [angular plugin](http://jimliu.github.io/angular-ui-tree/)).

I have created an example page which shows this feature in action, I wasn't quite sure how to build the `tmpl` files so I just did it manually.

 I tried to extend the existing code and keep this new handler style confined to a single coffescript file. I had to slightly modify the existing drag and drop class.

![gif-2](https://cloud.githubusercontent.com/assets/1691120/3436325/7f6905dc-009f-11e4-9bd3-db7aa2681ac1.gif)
