### PR TITLE
Fix for issue when moving node over closed folder

### DIFF
--- a/tree.jquery.js
+++ b/tree.jquery.js
@@ -2306,6 +2306,9 @@ limitations under the License.
           if (this.mustOpenFolderTimer(area)) {
             this.startOpenFolderTimer(area.node);
           }
+		  else {
+		    this.stopOpenFolderTimer();
+		  }
           this.updateDropHint();
         }
       } else {


### PR DESCRIPTION
There was a bug that happened when a node what moved over a closed folder.  The last folder that was hovered would open even if the node wasn't hovering the folder anymore. 

This fixes the issue.
