### PR TITLE
Add cloneNode missing argumen for Gecko <13.0 versions

### DIFF
--- a/src/elements_renderer.coffee
+++ b/src/elements_renderer.coffee
@@ -113,7 +113,7 @@ class ElementsRenderer
         button_link.className = "jqtree_common #{ button_classes }"
 
         button_link.appendChild(
-            icon_element.cloneNode()
+            icon_element.cloneNode(false)
         )
 
         div.appendChild(button_link)

--- a/src/tree.jquery.coffee
+++ b/src/tree.jquery.coffee
@@ -696,7 +696,7 @@ class FolderElement extends NodeElement
             $button = @getButton()
             $button.removeClass('jqtree-closed')
             $button.html('')
-            $button.append(@tree_widget.renderer.opened_icon_element.cloneNode())
+            $button.append(@tree_widget.renderer.opened_icon_element.cloneNode(false))
 
             doOpen = =>
                 @getLi().removeClass('jqtree-closed')
@@ -717,7 +717,7 @@ class FolderElement extends NodeElement
             $button = @getButton()
             $button.addClass('jqtree-closed')
             $button.html('')
-            $button.append(@tree_widget.renderer.closed_icon_element.cloneNode())
+            $button.append(@tree_widget.renderer.closed_icon_element.cloneNode(false))
 
             doClose = =>
                 @getLi().addClass('jqtree-closed')


### PR DESCRIPTION
## FireFox till 13v (Gecko 13) is causing exception error:

Error: uncaught exception: [Exception... "Not enough arguments"
nsresult: "0x80570001 (NS_ERROR_XPC_NOT_ENOUGH_ARGS)"  location: "JS
frame ::
file:///tree.jquery.js ::
:: anonymous :: line 904"  data: no]

---

Fixed by adding (default: false) argument to cloneNode method. For new browsers cloneNode
methods 'deep' argument is optional, but for older it wasn't.

From: https://developer.mozilla.org/en-US/docs/Web/API/Node.cloneNode
This behavior has been changed in the latest spec, and if omitted, the
method will act as if the value of deep was false. Though It's still
optional, you should always provide the deep argument both for backward
and forward compatibility.
