### PR TITLE
Set jquery as a peer dependency

### DIFF
--- a/docs/_entries/10_changelog.md
+++ b/docs/_entries/10_changelog.md
@@ -3,6 +3,11 @@ title: Changelog
 name: changelog
 ---
 
+### development version
+
+-   Issue #746: set jQuery as a peer dependency
+-   Issue #747: fix eslint import error
+
 #### 1.7.2 (september 14 2023)
 
 -   Issue #732: improve types of closedIcon and openedIcon

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     ],
     "license": "Apache-2.0",
     "browser": "./tree.jquery.js",
+    "main": "./tree.jquery.js",
     "types": "./src/tree.jquery.d.ts",
     "repository": {
         "type": "git",
@@ -27,8 +28,8 @@
         "playwright": "pnpm build-with-coverage && playwright test --config config/playwright.config.js",
         "test": "pnpm jest && pnpm playwright"
     },
-    "dependencies": {
-        "jquery": "^3.7.1"
+    "peerDependencies": {
+        "jquery": "^3"
     },
     "devDependencies": {
         "@babel/cli": "^7.22.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   jquery:
-    specifier: ^3.7.1
+    specifier: ^3
     version: 3.7.1
 
 devDependencies:


### PR DESCRIPTION
Also set the `main` entry in the package.json.

Fixes  #746 and #747