### PR TITLE
The tabindex entry in the docs has the wrong key

### DIFF
--- a/docs/_entries/options/tabindex.md
+++ b/docs/_entries/options/tabindex.md
@@ -1,6 +1,6 @@
 ---
 title: tabIndex
-name: tabIndex-slide
+name: tab-index
 ---
 
 Set the tabindex of the tree. The default is `0`.

--- a/docs/_entries/options/usecontextmenu.md
+++ b/docs/_entries/options/usecontextmenu.md
@@ -1,6 +1,6 @@
 ---
 title: useContextMenu
-name: usecontextmenu
+name: use-context-menu
 ---
 
 Bind the context menu event (true/false).


### PR DESCRIPTION
Fix  #866