### PR TITLE
Replace mockjax

### DIFF
--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,28 +1,34 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
+    <head>
+        <meta charset="utf-8" />
+        <title>
+            {% if page.title %}{{ page.title }}{% else %}{{ site.title }}{%
+            endif %}
+        </title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="JqTree is a jQuery widget for displaying a tree structure in html"
+        />
+        <link rel="stylesheet" href="{{ site.baseurl }}/static/monokai.css" />
+        <link
+            rel="stylesheet"
+            href="{{ site.baseurl }}/static/documentation.css"
+        />
+        <link rel="stylesheet" href="{{ site.baseurl }}/jqtree.css" />
+        <link rel="stylesheet" href="{{ site.baseurl }}/static/example.css" />
+    </head>
 
-<head>
-    <meta charset="utf-8" />
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="JqTree is a jQuery widget for displaying a tree structure in html" />
-    <link rel="stylesheet" href="{{ site.baseurl }}/static/monokai.css" />
-    <link rel="stylesheet" href="{{ site.baseurl }}/static/documentation.css" />
-    <link rel="stylesheet" href="{{ site.baseurl }}/jqtree.css" />
-    <link rel="stylesheet" href="{{ site.baseurl }}/static/example.css" />
-</head>
+    <body>
+        {{ content }}
+    </body>
 
-<body>
-    {{ content }}
-</body>
+    <script src="{{ site.baseurl }}/static/vendor/jquery.min.js"></script>
+    <script src="{{ site.baseurl }}/tree.jquery.js"></script>
+    <script src="{{ site.baseurl }}/static/example_data.js"></script>
 
-<script src="{{ site.baseurl }}/static/vendor/jquery.min.js"></script>
-<script src="{{ site.baseurl }}/tree.jquery.js"></script>
-<script src="{{ site.baseurl }}/static/vendor/jquery.mockjax.min.js"></script>
-<script src="{{ site.baseurl }}/static/example_data.js"></script>
-
-{% if page.js %}
-<script src="{{ site.baseurl }}/static/{{ page.js }}"></script>
-{% endif %}
-
+    {% if page.js %}
+    <script src="{{ site.baseurl }}/static/{{ page.js }}"></script>
+    {% endif %}
 </html>

--- a/docs/copy_vendor_files
+++ b/docs/copy_vendor_files
@@ -1,3 +1,2 @@
 mkdir -p static/vendor
-cp node_modules/jquery-mockjax/dist/jquery.mockjax.min.js static/vendor
 cp node_modules/jquery/dist/jquery.min.js static/vendor

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,6 @@
         "@tailwindcss/typography": "^0.5.19",
         "autoprefixer": "^10.4.23",
         "jquery": "^4.0.0",
-        "jquery-mockjax": "2.7.0-beta.0",
         "postcss": "^8.5.6",
         "postcss-cli": "^11.0.1",
         "postcss-import": "^16.1.1",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       jquery:
         specifier: ^4.0.0
         version: 4.0.0
-      jquery-mockjax:
-        specifier: 2.7.0-beta.0
-        version: 2.7.0-beta.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -407,9 +404,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  jquery-mockjax@2.7.0-beta.0:
-    resolution: {integrity: sha512-qn/RJijeLj1GNeMLLAGkZG9sha5muKCoj/e61bRKjXJZ6xKypq5K0hW/qxfQ2xDgyj5KwIRcLEpAomOsLa+qTQ==}
 
   jquery@4.0.0:
     resolution: {integrity: sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==}
@@ -998,8 +992,6 @@ snapshots:
   is-number@7.0.0: {}
 
   jiti@2.6.1: {}
-
-  jquery-mockjax@2.7.0-beta.0: {}
 
   jquery@4.0.0: {}
 

--- a/docs/static/examples/button-on-right.js
+++ b/docs/static/examples/button-on-right.js
@@ -1,13 +1,9 @@
-$.mockjax({
-    url: "*",
-    response: function(options) {
-        this.responseText = ExampleData.exampleData;
-    },
-    responseTime: 0
-});
+$.ajax = function (settings) {
+    settings.success(ExampleData.exampleData);
+};
 
 $("#tree1").tree({
     buttonLeft: false,
     autoOpen: 0,
-    slide: true
+    slide: true,
 });

--- a/docs/static/examples/drag-outside.js
+++ b/docs/static/examples/drag-outside.js
@@ -1,10 +1,6 @@
-$.mockjax({
-    url: "*",
-    response: function(options) {
-        this.responseText = ExampleData.exampleData;
-    },
-    responseTime: 0
-});
+$.ajax = function (settings) {
+    settings.success(ExampleData.exampleData);
+};
 
 var targetCollisionDiv = $("#targetDiv");
 
@@ -12,8 +8,7 @@ function isOverTarget(e) {
     return (
         e.clientX > targetCollisionDiv.position().left &&
         e.clientX <
-            targetCollisionDiv.position().left +
-                targetCollisionDiv.width() &&
+            targetCollisionDiv.position().left + targetCollisionDiv.width() &&
         e.clientY > targetCollisionDiv.position().top &&
         e.clientY <
             targetCollisionDiv.position().top + targetCollisionDiv.height()
@@ -33,5 +28,5 @@ function handleStop(node, e) {
 $("#tree1").tree({
     dragAndDrop: true,
     onDragMove: handleMove,
-    onDragStop: handleStop
+    onDragStop: handleStop,
 });

--- a/docs/static/examples/drag_and_drop.js
+++ b/docs/static/examples/drag_and_drop.js
@@ -1,13 +1,9 @@
-$.mockjax({
-    url: "*",
-    response: function(options) {
-        this.responseText = ExampleData.exampleData;
-    },
-    responseTime: 0
-});
+$.ajax = function (settings) {
+    settings.success(ExampleData.exampleData);
+};
 
 var $tree = $("#tree1");
 $tree.tree({
     dragAndDrop: true,
-    autoOpen: 0
+    autoOpen: 0,
 });

--- a/docs/static/examples/icon_buttons.js
+++ b/docs/static/examples/icon_buttons.js
@@ -1,10 +1,6 @@
-$.mockjax({
-    url: "*",
-    response: function () {
-        this.responseText = ExampleData.exampleData;
-    },
-    responseTime: 0,
-});
+$.ajax = function (settings) {
+    settings.success(ExampleData.exampleData);
+};
 
 $("#tree1").tree({
     closedIcon: $(

--- a/docs/static/examples/load_json_data_from_server.js
+++ b/docs/static/examples/load_json_data_from_server.js
@@ -1,9 +1,5 @@
-$.mockjax({
-    url: "*",
-    response: function(options) {
-        this.responseText = ExampleData.exampleData;
-    },
-    responseTime: 0
-});
+$.ajax = function (settings) {
+    settings.success(ExampleData.exampleData);
+};
 
 $("#tree1").tree();

--- a/docs/static/examples/load_on_demand.js
+++ b/docs/static/examples/load_on_demand.js
@@ -1,19 +1,15 @@
-$.mockjax({
-    url: "*",
-    responseTime: 1000,
-    response: function(options) {
-        if (options.data && options.data.node) {
-            this.responseText = ExampleData.getChildrenOfNode(
-                options.data.node
-            );
+$.ajax = function (settings) {
+    setTimeout(function () {
+        if (settings.data && settings.data.node) {
+            settings.success(ExampleData.getChildrenOfNode(settings.data.node));
         } else {
-            this.responseText = ExampleData.getFirstLevelData();
+            settings.success(ExampleData.getFirstLevelData());
         }
-    }
-});
+    }, 1000);
+};
 
 var $tree = $("#tree1");
 
 $tree.tree({
-    saveState: true
+    saveState: true,
 });

--- a/docs/static/examples/right-to-left.js
+++ b/docs/static/examples/right-to-left.js
@@ -1,11 +1,7 @@
-$.mockjax({
-    url: "*",
-    response: function(options) {
-        this.responseText = ExampleData.exampleData;
-    },
-    responseTime: 0
-});
+$.ajax = function (settings) {
+    settings.success(ExampleData.exampleData);
+};
 
 $("#tree1").tree({
-    rtl: true
+    rtl: true,
 });

--- a/docs/static/examples/save_state.js
+++ b/docs/static/examples/save_state.js
@@ -1,11 +1,7 @@
-$.mockjax({
-    url: "*",
-    response: function(options) {
-        this.responseText = ExampleData.exampleData;
-    },
-    responseTime: 0
-});
+$.ajax = function (settings) {
+    settings.success(ExampleData.exampleData);
+};
 
 $("#tree1").tree({
-    saveState: true
+    saveState: true,
 });


### PR DESCRIPTION
Let's replace jquery-mockjax. The package isn't updated since 2024. The last release is a beta version.